### PR TITLE
Replace std_error with se

### DIFF
--- a/inst/simulations/mc-el.R
+++ b/inst/simulations/mc-el.R
@@ -34,7 +34,7 @@ run_mc_once <- function(N, alpha, i) {
   if (inherits(fit, "try-error") || !isTRUE(fit$converged)) {
     return(list(ok = FALSE))
   }
-  list(ok = TRUE, y_hat = fit$estimate, se = fit$std_error)
+  list(ok = TRUE, y_hat = fit$estimate, se = fit$se)
 }
 
 run_mc <- function(N, alpha, reps = 20L, true_mean = 2.0, seed = 1L) {
@@ -64,7 +64,7 @@ run_mc_bootstrap <- function(N, alpha, reps = 20L, true_mean = 2.0, seed = 1L, b
     if (inherits(fit, "try-error") || !isTRUE(fit$converged)) {
       list(ok = FALSE)
     } else {
-      list(ok = TRUE, y_hat = fit$estimate, se = fit$std_error)
+      list(ok = TRUE, y_hat = fit$estimate, se = fit$se)
     }
   }, simplify = FALSE)
   ok <- vapply(vals, function(v) isTRUE(v$ok), logical(1))
@@ -145,7 +145,7 @@ run_mc_survey_once <- function(N, alpha, gamma, i) {
   if (inherits(fit, "try-error") || !isTRUE(fit$converged)) {
     return(list(ok = FALSE))
   }
-  list(ok = TRUE, y_hat = fit$estimate, se = fit$std_error)
+  list(ok = TRUE, y_hat = fit$estimate, se = fit$se)
 }
 
 run_mc_survey <- function(N, alpha, gamma = 0.7, reps = 20L, true_mean = 2.0, seed = 1L) {
@@ -177,7 +177,7 @@ run_mc_survey_bootstrap <- function(N, alpha, gamma = 0.7, reps = 20L, true_mean
     if (inherits(fit, "try-error") || !isTRUE(fit$converged)) {
       list(ok = FALSE)
     } else {
-      list(ok = TRUE, y_hat = fit$estimate, se = fit$std_error)
+      list(ok = TRUE, y_hat = fit$estimate, se = fit$se)
     }
   }, simplify = FALSE)
   ok <- vapply(vals, function(v) isTRUE(v$ok), logical(1))

--- a/src_dev/S3/nmar_result_constructors.R
+++ b/src_dev/S3/nmar_result_constructors.R
@@ -8,7 +8,7 @@ new_nmar_result <- function(...) {
   dots <- list(...)
 
   estimate <- dots$estimate
-  std_error <- dots$std_error
+  se <- dots$se
   estimate_name <- dots$estimate_name %||% NA_character_
   converged <- dots$converged
   model <- dots$model %||% list()
@@ -53,7 +53,7 @@ new_nmar_result <- function(...) {
   result <- list(
     estimate = estimate,
     estimate_name = estimate_name,
-    std_error = std_error,
+    se = se,
     converged = converged,
     model = model,
     weights_info = weights_info,

--- a/src_dev/S3/nmar_result_methods.R
+++ b/src_dev/S3/nmar_result_methods.R
@@ -7,7 +7,7 @@
 #'   or extend behavior.
 #' @details
 #'   Result objects expose a universal schema:
-#'   - `estimate`, `estimate_name`, `std_error`, `converged`.
+#'   - `estimate`, `estimate_name`, `se`, `converged`.
 #'   - `model`: list with `coefficients`, `vcov`, plus optional extras.
 #'   - `weights_info`: list with respondent weights and trimming metadata.
 #'   - `sample`: list with total units, respondent count, survey flag, and `design`.
@@ -33,7 +33,7 @@ NULL
 #' @keywords result_param
 #' @export
 vcov.nmar_result <- function(object, ...) {
-  se <- nmar_result_get_std_error(object)
+  se <- nmar_result_get_se(object)
   if (length(se) == 1 && is.finite(se)) {
     mat <- matrix(as.numeric(se)^2, 1, 1)
   } else {
@@ -52,7 +52,7 @@ vcov.nmar_result <- function(object, ...) {
 #' @keywords result_param
 #' @export
 confint.nmar_result <- function(object, parm, level = 0.95, ...) {
-  se <- nmar_result_get_std_error(object)
+  se <- nmar_result_get_se(object)
   nm <- nmar_result_get_estimate_name(object)
   est <- nmar_result_get_estimate(object)
   if (!is.finite(se)) {
@@ -82,7 +82,7 @@ confint.nmar_result <- function(object, parm, level = 0.95, ...) {
 #' @exportS3Method tidy nmar_result
 tidy.nmar_result <- function(x, conf.level = 0.95, ...) {
   est <- nmar_result_get_estimate(x)
-  se <- nmar_result_get_std_error(x)
+  se <- nmar_result_get_se(x)
   nm <- nmar_result_get_estimate_name(x)
   inference <- nmar_result_get_inference(x)
   sample <- nmar_result_get_sample(x)
@@ -149,7 +149,7 @@ tidy.nmar_result <- function(x, conf.level = 0.95, ...) {
 #' @exportS3Method glance nmar_result
 glance.nmar_result <- function(x, ...) {
   est <- nmar_result_get_estimate(x)
-  se <- nmar_result_get_std_error(x)
+  se <- nmar_result_get_se(x)
   inference <- nmar_result_get_inference(x)
   sample <- nmar_result_get_sample(x)
   diagnostics <- nmar_result_get_diagnostics(x)
@@ -334,3 +334,21 @@ weights.nmar_result <- function(object, ...) {
 formula.nmar_result <- function(x, ...) {
   x$meta$formula %||% NULL
 }
+
+#' Extract standard error (SE) for NMAR results
+#'
+#' Convenience extractor for the standard error of the reported mean.
+#' Returns a single numeric value or NA if unavailable.
+#' @param object An `nmar_result`.
+#' @param ... Ignored.
+#' @return Numeric scalar.
+#' Extract standard error (SE)
+#' @description Returns the standard error of the primary mean estimate.
+#' @param object An `nmar_result` or subclass.
+#' @param ... Ignored.
+#' @return Numeric scalar.
+#' @export
+se <- function(object, ...) UseMethod("se")
+
+#' @export
+se.nmar_result <- function(object, ...) nmar_result_get_se(object)

--- a/src_dev/S3/nmar_result_utils.R
+++ b/src_dev/S3/nmar_result_utils.R
@@ -5,10 +5,7 @@ nmar_result_get_estimate <- function(x) {
   x$estimate %||% NA_real_
 }
 
-#' @keywords internal
-nmar_result_get_std_error <- function(x) {
-  x$std_error %||% NA_real_
-}
+
 
 #' @keywords internal
 nmar_result_get_estimate_name <- function(x) {
@@ -57,6 +54,26 @@ nmar_result_get_model <- function(x) {
   model$coefficients <- model$coefficients %||% NULL
   model$vcov <- model$vcov %||% NULL
   model
+}
+
+#' @keywords internal
+nmar_result_get_se <- function(x) {
+  x$se %||% NA_real_
+}
+
+#' Resolve global digits setting for printing
+#' @keywords internal
+nmar_get_digits <- function() {
+  d <- getOption("nmar.digits", 6L)
+  if (!is.numeric(d) || length(d) != 1L || is.na(d) || d < 0) return(6L)
+  as.integer(d)
+}
+
+#' Format a number with fixed decimal places using nmar.digits
+#' @keywords internal
+nmar_fmt_num <- function(x, digits = nmar_get_digits()) {
+  if (!is.finite(x)) return("NA")
+  sprintf(paste0("%0.", digits, "f"), as.numeric(x))
 }
 
 #' Format an abridged call line for printing

--- a/src_dev/S3/nmar_result_validator.R
+++ b/src_dev/S3/nmar_result_validator.R
@@ -12,8 +12,8 @@ validate_nmar_result <- function(x, class_name) {
   if (is.null(x$estimate)) stop("`estimate` must be supplied by the result object.")
   if (length(x$estimate) != 1 || !is.numeric(x$estimate)) stop("`estimate` must be a numeric scalar.")
 
-  if (is.null(x$std_error)) x$std_error <- NA_real_
-  if (length(x$std_error) != 1 || !is.numeric(x$std_error)) stop("`std_error` must be a numeric scalar (NA allowed).")
+  if (is.null(x$se)) x$se <- NA_real_
+  if (length(x$se) != 1 || !is.numeric(x$se)) stop("`se` must be a numeric scalar (NA allowed).")
 
   if (is.null(x$estimate_name)) x$estimate_name <- NA_character_
   if (length(x$estimate_name) != 1) stop("`estimate_name` must be a character scalar (NA allowed).")

--- a/src_dev/engines/el/impl/constructors.R
+++ b/src_dev/engines/el/impl/constructors.R
@@ -45,7 +45,7 @@ new_nmar_result_el <- function(y_hat, se, weights, coefficients, vcov,
   result <- new_nmar_result(
     estimate = y_hat,
     estimate_name = outcome_name,
-    std_error = se,
+    se = se,
     converged = converged,
     model = list(
       coefficients = response_coeffs,

--- a/src_dev/engines/el/impl/dataframe.R
+++ b/src_dev/engines/el/impl/dataframe.R
@@ -103,7 +103,7 @@ el.data.frame <- function(data, formula, response_predictors = NULL,
     result <- new_nmar_result(
       estimate = NA_real_,
       estimate_name = sample_info$outcome_var,
-      std_error = NA_real_,
+      se = NA_real_,
       converged = FALSE,
       model = list(coefficients = NULL, vcov = NULL),
       weights_info = list(values = numeric(0), trimmed_fraction = NA_real_),

--- a/src_dev/engines/el/impl/survey.R
+++ b/src_dev/engines/el/impl/survey.R
@@ -109,7 +109,7 @@ el.survey.design <- function(data, formula, response_predictors = NULL,
     result <- new_nmar_result(
       estimate = NA_real_,
       estimate_name = sample_info$outcome_var,
-      std_error = NA_real_,
+      se = NA_real_,
       converged = FALSE,
       model = list(coefficients = NULL, vcov = NULL),
       weights_info = list(values = numeric(0), trimmed_fraction = NA_real_),

--- a/src_dev/engines/exptilt/impl/constructors.R
+++ b/src_dev/engines/exptilt/impl/constructors.R
@@ -1,5 +1,5 @@
 #' @keywords internal
-new_nmar_result_exptilt <- function(estimate, std_error, coefficients, vcov, model,
+new_nmar_result_exptilt <- function(estimate, se, coefficients, vcov, model,
                                     converged = TRUE, weights = NULL,
                                     variance_message = NA_character_) {
   outcome_name <- model$col_y %||% NA_character_
@@ -19,9 +19,9 @@ new_nmar_result_exptilt <- function(estimate, std_error, coefficients, vcov, mod
     tol_value = model$tol_value
   )
 
-  # The unified data-frame/survey path populates model$is_survey, we also
-  # honor designs that arrive directly via the survey method so result
-  # metadata reflects the original call
+# The unified data-frame/survey path populates model$is_survey, we also
+# honor designs that arrive directly via the survey method so result
+# metadata reflects the original call
   is_survey <- isTRUE(model$is_survey) || inherits(model$design, "survey.design")
   sample <- list(
     n_total = n_total,
@@ -50,7 +50,7 @@ new_nmar_result_exptilt <- function(estimate, std_error, coefficients, vcov, mod
   result <- new_nmar_result(
     estimate = estimate,
     estimate_name = outcome_name,
-    std_error = std_error,
+    se = se,
     converged = converged,
     model = list(
       coefficients = coeffs_vec,

--- a/src_dev/engines/exptilt/impl/dataframe.R
+++ b/src_dev/engines/exptilt/impl/dataframe.R
@@ -76,21 +76,21 @@ exptilt_fit_model <- function(data, model, on_failure = c("return", "error"), ..
   if (is.null(model$standardize)) {
     model$standardize <- TRUE
   }
-  # Cache the pre-fit template so bootstrap replicates can start from the same
-  # initial state (rather than inheriting mutated fields from the first fit)
+# Cache the pre-fit template so bootstrap replicates can start from the same
+# initial state (rather than inheriting mutated fields from the first fit)
   bootstrap_template <- unserialize(serialize(model, NULL))
   model$cols_required <- colnames(model$x)
   bootstrap_template$cols_required <- model$cols_required
-  # model$x_1 <- model$x[!is.na(model$x[,model$col_y]),,drop=FALSE] #observed
-  # model$x_0 <- model$x[is.na(model$x[,model$col_y]),,drop=FALSE] #unobserved
-  # model$y_1 <- model$x_1[,model$col_y,drop=TRUE] #observed y
-  #
-  # model$x_for_y_obs <- model$x_1[,model$cols_y_observed,drop=FALSE]
-  # model$x_for_y_unobs <- model$x_0[,model$cols_y_observed,drop=FALSE]
+# model$x_1 <- model$x[!is.na(model$x[,model$col_y]),,drop=FALSE] #observed
+# model$x_0 <- model$x[is.na(model$x[,model$col_y]),,drop=FALSE] #unobserved
+# model$y_1 <- model$x_1[,model$col_y,drop=TRUE] #observed y
+#
+# model$x_for_y_obs <- model$x_1[,model$cols_y_observed,drop=FALSE]
+# model$x_for_y_unobs <- model$x_0[,model$cols_y_observed,drop=FALSE]
 
   has_aux <- length(model$cols_y_observed) > 0 && !is.null(model$auxiliary_means)
-  # Retain auxiliary means only for RHS predictors present in this fit, this
-  # keeps scaling consistent when users supply a superset of moments
+# Retain auxiliary means only for RHS predictors present in this fit, this
+# keeps scaling consistent when users supply a superset of moments
   filtered_aux_means <- if (has_aux) {
     aux_names <- intersect(names(model$auxiliary_means), model$cols_y_observed)
     model$auxiliary_means[aux_names]
@@ -98,21 +98,21 @@ exptilt_fit_model <- function(data, model, on_failure = c("return", "error"), ..
     NULL
   }
 
-  # Store design weights so downstream components (score, variance, C-matrix)
-  # all see the same vector. For plain data frames, fall back to weight 1 if
-  # the caller has not already supplied model$design_weights (the survey
-  # method pre-populates this vector)
-  # if (is.null(model$design_weights) || length(model$design_weights) != nrow(model$x)) {
-  #   model$design_weights <- rep(1, nrow(model$x))
-  # }
+# Store design weights so downstream components (score, variance, C-matrix)
+# all see the same vector. For plain data frames, fall back to weight 1 if
+# the caller has not already supplied model$design_weights (the survey
+# method pre-populates this vector)
+# if (is.null(model$design_weights) || length(model$design_weights) != nrow(model$x)) {
+#   model$design_weights <- rep(1, nrow(model$x))
+# }
 
   respondent_mask <- !is.na(model$x[, model$col_y])
   model$respondent_mask <- respondent_mask
-  # browser()
+# browser()
 
   scaling_weights <- model$design_weights
-  # When scaling we only want respondent rows to contribute; pass a mask so the
-  # helper can zero-out nonrespondents without reallocating weights
+# When scaling we only want respondent rows to contribute; pass a mask so the
+# helper can zero-out nonrespondents without reallocating weights
   weight_mask <- if (length(respondent_mask) == nrow(model$x)) respondent_mask else NULL
 
   scaling_result <- validate_and_apply_nmar_scaling(
@@ -135,24 +135,24 @@ exptilt_fit_model <- function(data, model, on_failure = c("return", "error"), ..
   model$x_for_y_obs <- auxiliary_matrix_scaled[respondent_mask, , drop = FALSE]
   model$x_for_y_unobs <- auxiliary_matrix_scaled[!respondent_mask, , drop = FALSE]
 
-  if(model$is_survey==F) model$respondent_weights <- rep(1, nrow(model$x_1)) else model$respondent_weights <-weights(model$x_1)
+  if (model$is_survey == F) model$respondent_weights <- rep(1, nrow(model$x_1)) else model$respondent_weights <- weights(model$x_1)
 
 
-  # Track the current scale of feature matrices. We fit f1(.) on the scaled
-  # space and compute EM steps there. After unscaling coefficients for
-  # presentation we flip this flag to FALSE so downstream density evaluations
-  # can re-apply the same scaling recipe to inputs as needed
+# Track the current scale of feature matrices. We fit f1(.) on the scaled
+# space and compute EM steps there. After unscaling coefficients for
+# presentation we flip this flag to FALSE so downstream density evaluations
+# can re-apply the same scaling recipe to inputs as needed
   model$features_are_scaled <- TRUE
 
 
-  # We will derive respondent/nonrespondent weight slices on the fly from
-  # design_weights using the stored masks to avoid duplicating state
+# We will derive respondent/nonrespondent weight slices on the fly from
+# design_weights using the stored masks to avoid duplicating state
 
   model$theta <- stats::runif(length(model$cols_delta) + 2, 0, 0.1)
-  # Name the parameter vector to align with the design vector used throughout
-  # the ET implementation: [ (Intercept), x1 (cols_delta...), y ].  These names
-  # are required by the shared scaling unscaler so coefficients are returned on
-  # the original (unscaled) feature space after solving
+# Name the parameter vector to align with the design vector used throughout
+# the ET implementation: [ (Intercept), x1 (cols_delta...), y ].  These names
+# are required by the shared scaling unscaler so coefficients are returned on
+# the original (unscaled) feature space after solving
   names(model$theta) <- c("(Intercept)", model$cols_delta, model$col_y)
 
   dens_response <- generate_conditional_density(model)
@@ -164,7 +164,7 @@ exptilt_fit_model <- function(data, model, on_failure = c("return", "error"), ..
   model$chosen_y_dens <- dens_response$chosen_distribution
   model$O_matrix_nieobs <- generate_Odds(model)
 
-  # const
+# const
   model$f_matrix_nieobs <- generate_conditional_density_matrix(model)
   model$C_matrix_nieobs <- generate_C_matrix(model)
 
@@ -228,9 +228,9 @@ exptilt_estimator_core <- function(model, bootstrap_template, respondent_mask,
 
   model$x_for_y_obs <- model$x_1[, model$cols_y_observed, drop = FALSE]
   model$x_for_y_unobs <- model$x_0[, model$cols_y_observed, drop = FALSE]
-  # From this point the feature matrices are on the original (unscaled) space
-  # density helpers will internally re-apply the scaling recipe captured during
-  # model fitting so that gamma_hat remains consistent
+# From this point the feature matrices are on the original (unscaled) space
+# density helpers will internally re-apply the scaling recipe captured during
+# model fitting so that gamma_hat remains consistent
   model$features_are_scaled <- FALSE
 
   model$O_matrix_nieobs <- generate_Odds(model)
@@ -254,48 +254,48 @@ exptilt_estimator_core <- function(model, bootstrap_template, respondent_mask,
     }
   }
 
-  # If heuristics later steer us back to the bootstrap path, discard the delta
-  # variance so downstream code reports NA rather than an unreliable number
+# If heuristics later steer us back to the bootstrap path, discard the delta
+# variance so downstream code reports NA rather than an unreliable number
   if (isTRUE(model$is_survey) && !use_bootstrap) {
-    # The current implementation of analytic delta variance assumes IID sampling: it plugs
-    # respondent/nonrespondent scores into the Fisher blocks (F11, F21, F22) and
-    # combines them with the linearized estimating system S2(phi) to get var(tau_hat).
-    # Under complex designs the weights themselves change across replicates and
-    # the design induces correlation within PSUs/strata, so the IID "closed-form
-    # Sigma" (i.e., B = Var(S) where S = sum_i s_i is computed as a simple crossproduct/covariance)
-    # is no longer valid.
-    #
-    # To obtain a design-consistent analytic variance one of two routes is needed:
-    #  1) Replicate-weight linearization: for each set of replicate weights,
-    #     recompute the ET quantities that depend on weights (S2(phi), F11, F21,
-    #     F22, fractional weights w_ij, and any density-derivative sums) and then
-    #     pass replicate estimates (or score totals) to survey::withReplicates()
-    #     and survey::svrVar() to aggregate the design variance with the proper
-    #     scaling. The "score contrasts" here are the per-replicate
-    #     deviations of the totals/estimates from the full-sample target used by
-    #     svrVar to form Sigma.
-    #  2) Analytic influence-function path: derive per-unit linearized variables
-    #     (analytic influence functions) for phi_hat and tau_hat under ET, evaluated at the
-    #     full-sample fit, and hand them to survey::svyrecvar() (or the design's
-    #     replicate engine) to compute the design-based variance without refitting
-    #     replicates. This still requires careful propagation of respondent and
-    #     fractional-imputation weights through the ET linearization.
-    # Either approach would touch estim_var() (replace the IID "closed-form Sigma"
-    # with replicate or linearized aggregation) and likely add a small adapter akin
-    # to our bootstrap helper to drive replication. Until such a derivation is
-    # implemented, we always use bootstrap variance for survey designs to avoid
-    # under- or over-stating uncertainty. See Remark 2 form the Riddles paper for the
-    # weighting subtleties that must be preserved under replication.
+# The current implementation of analytic delta variance assumes IID sampling: it plugs
+# respondent/nonrespondent scores into the Fisher blocks (F11, F21, F22) and
+# combines them with the linearized estimating system S2(phi) to get var(tau_hat).
+# Under complex designs the weights themselves change across replicates and
+# the design induces correlation within PSUs/strata, so the IID "closed-form
+# Sigma" (i.e., B = Var(S) where S = sum_i s_i is computed as a simple crossproduct/covariance)
+# is no longer valid.
+#
+# To obtain a design-consistent analytic variance one of two routes is needed:
+#  1) Replicate-weight linearization: for each set of replicate weights,
+#     recompute the ET quantities that depend on weights (S2(phi), F11, F21,
+#     F22, fractional weights w_ij, and any density-derivative sums) and then
+#     pass replicate estimates (or score totals) to survey::withReplicates()
+#     and survey::svrVar() to aggregate the design variance with the proper
+#     scaling. The "score contrasts" here are the per-replicate
+#     deviations of the totals/estimates from the full-sample target used by
+#     svrVar to form Sigma.
+#  2) Analytic influence-function path: derive per-unit linearized variables
+#     (analytic influence functions) for phi_hat and tau_hat under ET, evaluated at the
+#     full-sample fit, and hand them to survey::svyrecvar() (or the design's
+#     replicate engine) to compute the design-based variance without refitting
+#     replicates. This still requires careful propagation of respondent and
+#     fractional-imputation weights through the ET linearization.
+# Either approach would touch estim_var() (replace the IID "closed-form Sigma"
+# with replicate or linearized aggregation) and likely add a small adapter akin
+# to our bootstrap helper to drive replication. Until such a derivation is
+# implemented, we always use bootstrap variance for survey designs to avoid
+# under- or over-stating uncertainty. See Remark 2 form the Riddles paper for the
+# weighting subtleties that must be preserved under replication.
     use_bootstrap <- TRUE
   }
   if (identical(model$variance_method, "delta") && !identical(model$chosen_y_dens, "normal")) {
     warning("Delta variance unavailable for y_dens='", model$chosen_y_dens, "'; falling back to bootstrap.", call. = FALSE)
   }
   if (identical(model$variance_method, "delta") && identical(model$chosen_y_dens, "normal")) {
-    # Heuristic guard: the linearization in Riddles et al. assumes a reasonably
-    # large respondent pool and light weighting. If the sample has few
-    # respondents or highly uneven weights, steering to the bootstrap tends to
-    # give more stable uncertainty estimates
+# Heuristic guard: the linearization in Riddles et al. assumes a reasonably
+# large respondent pool and light weighting. If the sample has few
+# respondents or highly uneven weights, steering to the bootstrap tends to
+# give more stable uncertainty estimates
 
     resp_w_local <- model$design_weights[respondent_mask]
     n_resp <- length(resp_w_local)
@@ -341,8 +341,8 @@ exptilt_estimator_core <- function(model, bootstrap_template, respondent_mask,
       bootstrap_reps = model$bootstrap_reps
     )
     if (!model$is_survey) {
-      # Guard: resample until a respondent is present so EM/variance code can
-      # evaluate each replicate. Fallback to NA (with warning) if this fails
+# Guard: resample until a respondent is present so EM/variance code can
+# evaluate each replicate. Fallback to NA (with warning) if this fails
       respondent_mask_guard <- respondent_mask
       base_args$resample_guard <- function(indices, data) {
         any(respondent_mask_guard[indices])
@@ -357,7 +357,7 @@ exptilt_estimator_core <- function(model, bootstrap_template, respondent_mask,
 
   result <- new_nmar_result_exptilt(
     estimate = estim_mean(model),
-    std_error = se_final,
+    se = se_final,
     coefficients = model$theta,
     vcov = var_results$vcov,
     model = model,

--- a/tests/testthat/test-bootstrap.R
+++ b/tests/testthat/test-bootstrap.R
@@ -10,7 +10,7 @@ bootstrap_dummy_estimator <- function(data, on_failure = "return") {
     list(
       estimate = est,
       estimate_name = "y",
-      std_error = NA_real_,
+      se = NA_real_,
       converged = TRUE,
       sample = list(is_survey = inherits(data, "survey.design")),
       inference = list(),

--- a/tests/testthat/test-el-integration.R
+++ b/tests/testthat/test-el-integration.R
@@ -8,7 +8,7 @@ test_that("EL engine runs and returns expected structure (data.frame)", {
   expect_s3_class(res, "nmar_result_el")
   expect_true(isTRUE(res$converged))
   expect_true(is.numeric(res[['estimate']]))
-  expect_true(is.numeric(res[['std_error']]))
+  expect_true(is.numeric(res[['se']]))
 
   est <- res[['estimate']]
   expect_equal(as.numeric(est), res[['estimate']])

--- a/tests/testthat/test-el-probit-family.R
+++ b/tests/testthat/test-el-probit-family.R
@@ -5,7 +5,7 @@ test_that("EL engine runs with probit family (data.frame)", {
   fit <- nmar(formula = Y_miss ~ X, data = df, engine = eng)
   expect_true(fit$converged)
   expect_true(is.finite(fit[['estimate']]))
-  expect_true(is.finite(fit[['std_error']]))
+  expect_true(is.finite(fit[['se']]))
 })
 
 test_that("Estimating equations solved for probit family (max residual small)", {

--- a/tests/testthat/test-el-response-extra-predictors.R
+++ b/tests/testthat/test-el-response-extra-predictors.R
@@ -16,8 +16,8 @@ test_that("response_predictors can include non-auxiliary variables", {
 
   expect_s3_class(res, "nmar_result_el")
   expect_true(isTRUE(res$converged))
-  expect_true(is.numeric(res[['std_error']]))
-  expect_true(is.na(res[['std_error']]) || res[['std_error']] >= 0)
+  expect_true(is.numeric(res[['se']]))
+  expect_true(is.na(res[['se']]) || res[['se']] >= 0)
 # Coefficient vector should include Z as a response predictor
   expect_true(any(grepl("(^|\\b)Z(\\b|$)", names(res$model$coefficients))))
 })

--- a/tests/testthat/test-el-survey.R
+++ b/tests/testthat/test-el-survey.R
@@ -19,7 +19,7 @@ test_that("EL survey path produces finite SE and df when survey available", {
   )
   fit <- nmar(y_miss ~ x, data = design, engine = eng)
   expect_true(isTRUE(fit$converged))
-  se <- nmar_result_get_std_error(fit)
+  se <- NMAR:::nmar_result_get_se(fit)
   expect_true(is.finite(se))
   inf <- nmar_result_get_inference(fit)
   expect_true(is.finite(inf$df) || is.na(inf$df))

--- a/tests/testthat/test-el-variance-none.R
+++ b/tests/testthat/test-el-variance-none.R
@@ -29,7 +29,7 @@ test_that("variance_method = 'none' skips variance for IID and survey", {
                                   variance_method = "none",
                                   bootstrap_reps = 10))
     }
-    expect_true(is.na(fit$std_error))
+    expect_true(is.na(fit$se))
     expect_true(all(is.na(fit$model$vcov)))
     expect_match(fit$diagnostics$vcov_message, "Variance skipped")
   }

--- a/tests/testthat/test-el-variance-trim.R
+++ b/tests/testthat/test-el-variance-trim.R
@@ -13,14 +13,14 @@ test_that("delta uses analytic ∇g when untrimmed and numeric when trimmed (ind
                            auxiliary_means = aux_means, trim_cap = Inf,
                            standardize = TRUE)
   fit_inf_1 <- nmar(Y_miss ~ X, data = df, engine = eng_inf_1)
-  se_inf_1 <- fit_inf_1$std_error
+  se_inf_1 <- fit_inf_1$se
 
   options(nmar.grad_eps = 1e-2, nmar.grad_d = 1e-1)
   eng_inf_2 <- make_engine(variance_method = "delta", family = "logit",
                            auxiliary_means = aux_means, trim_cap = Inf,
                            standardize = TRUE)
   fit_inf_2 <- nmar(Y_miss ~ X, data = df, engine = eng_inf_2)
-  se_inf_2 <- fit_inf_2$std_error
+  se_inf_2 <- fit_inf_2$se
 
 # Expect near equality under smooth case
   expect_equal(se_inf_1, se_inf_2, tolerance = 1e-6)
@@ -31,7 +31,7 @@ test_that("delta uses analytic ∇g when untrimmed and numeric when trimmed (ind
                             auxiliary_means = aux_means, trim_cap = 1.1,
                             standardize = TRUE)
   fit_trim_1 <- nmar(Y_miss ~ X, data = df, engine = eng_trim_1)
-  se_trim_1 <- fit_trim_1$std_error
+  se_trim_1 <- fit_trim_1$se
 # Ensure trimming engaged
   expect_gt(fit_trim_1$diagnostics$trimmed_fraction, 0)
 
@@ -40,7 +40,7 @@ test_that("delta uses analytic ∇g when untrimmed and numeric when trimmed (ind
                             auxiliary_means = aux_means, trim_cap = 1.1,
                             standardize = TRUE)
   fit_trim_2 <- nmar(Y_miss ~ X, data = df, engine = eng_trim_2)
-  se_trim_2 <- fit_trim_2$std_error
+  se_trim_2 <- fit_trim_2$se
 
 # Expect larger difference under trimmed (non-smooth) case
   expect_gt(abs(se_trim_1 - se_trim_2), 1e-5)

--- a/tests/testthat/test-el-variance.R
+++ b/tests/testthat/test-el-variance.R
@@ -7,10 +7,10 @@ test_that("bootstrap and delta SE differ on typical df case", {
   fit_b <- nmar(formula = fml, data = df, engine = make_engine(auxiliary_means = c(X = 0), variance_method = "bootstrap", bootstrap_reps = 50, standardize = FALSE, suppress_warnings = TRUE))
 
   expect_true(fit_d$converged && fit_b$converged)
-  expect_true(is.finite(fit_d[['std_error']]))
-  expect_true(is.na(fit_b[['std_error']]) || is.finite(fit_b[['std_error']]))
-  if (isTRUE(is.finite(fit_b[['std_error']]))) {
-    expect_false(isTRUE(all.equal(fit_d[['std_error']], fit_b[['std_error']])))
+  expect_true(is.finite(fit_d[['se']]))
+  expect_true(is.na(fit_b[['se']]) || is.finite(fit_b[['se']]))
+  if (isTRUE(is.finite(fit_b[['se']]))) {
+    expect_false(isTRUE(all.equal(fit_d[['se']], fit_b[['se']])))
   }
 })
 

--- a/tests/testthat/test-exptilt-integration.R
+++ b/tests/testthat/test-exptilt-integration.R
@@ -3,14 +3,14 @@
 test_that("exptilt converges on simple IID example", {
   skip_if(Sys.getenv("NMAR_RUN_INTEGRATION") != "1", "Set NMAR_RUN_INTEGRATION=1 to run integration tests.")
   set.seed(123)
-  # Use a moderately sized synthetic sample so the analytic delta variance
-  # has a stable Fisher information (avoids singular FI22 in tiny samples)
+# Use a moderately sized synthetic sample so the analytic delta variance
+# has a stable Fisher information (avoids singular FI22 in tiny samples)
   n <- 200
   x1 <- rnorm(n)
   x2 <- rnorm(n)
   y_true <- 0.5 + 0.3 * x1 - 0.2 * x2 + rnorm(n, sd = 0.2)
   respond <- rbinom(n, 1, plogis(2 + 0.1 * y_true))
-  if (all(respond == 1)) respond[sample.int(n, 1)] <- 0  # ensure at least one missing
+  if (all(respond == 1)) respond[sample.int(n, 1)] <- 0 # ensure at least one missing
   y_obs <- ifelse(respond == 1, y_true, NA)
   dat <- data.frame(y = y_obs, x1 = x1, x2 = x2)
 
@@ -27,20 +27,20 @@ test_that("exptilt converges on simple IID example", {
   )
   expect_true(fit$converged)
   expect_true(is.finite(fit$estimate))
-  expect_true(is.finite(fit$std_error))
+  expect_true(is.finite(fit$se))
 
-  # The fit surfaces successfully and produces finite estimates
-  expect_true(is.finite(fit$std_error))
+# The fit surfaces successfully and produces finite estimates
+  expect_true(is.finite(fit$se))
 })
 
 test_that("exptilt handles simple survey design", {
   skip_if(Sys.getenv("NMAR_RUN_INTEGRATION") != "1", "Set NMAR_RUN_INTEGRATION=1 to run integration tests.")
   skip_if_not_installed("survey")
   set.seed(321)
-  # Larger survey sample keeps replicate fits numerically stable during
-  # bootstrap variance calculations
-  # Keep runtime contained for local integration runs while still exercising
-  # the survey/bootstrap code path
+# Larger survey sample keeps replicate fits numerically stable during
+# bootstrap variance calculations
+# Keep runtime contained for local integration runs while still exercising
+# the survey/bootstrap code path
   n <- 120
   x1 <- rnorm(n)
   x2 <- rnorm(n)

--- a/tests/testthat/test-exptilt-scaling-invariance.R
+++ b/tests/testthat/test-exptilt-scaling-invariance.R
@@ -12,7 +12,7 @@ test_that("exptilt scaling yields near-invariant estimates (IID)", {
   y_obs[delta == 0] <- NA_real_
   dat <- data.frame(y = y_obs, x1 = x1, x2 = x2)
 
-  # Fit with automatic standardization
+# Fit with automatic standardization
   fit_std <- nmar(
     y ~ x1 + x2,
     data = dat,
@@ -28,7 +28,7 @@ test_that("exptilt scaling yields near-invariant estimates (IID)", {
   )
   expect_true(fit_std$converged)
 
-  # Manual scaling recipe from respondents, then fit without standardize
+# Manual scaling recipe from respondents, then fit without standardize
   obs_mask <- !is.na(dat$y)
   Z_un <- model.matrix(~ y + x1 + x2, data = dat[obs_mask, ])
   X_un <- model.matrix(~ x1 + x2 - 1, data = dat[obs_mask, ])
@@ -53,15 +53,14 @@ test_that("exptilt scaling yields near-invariant estimates (IID)", {
   )
   expect_true(fit_raw$converged)
 
-  # Unscale the raw fit back to the original Y scale
+# Unscale the raw fit back to the original Y scale
   est_raw_unscaled <- as.numeric(fit_raw$estimate * recipe$y$sd + recipe$y$mean)
-  se_raw_unscaled <- as.numeric(fit_raw$std_error * recipe$y$sd)
+  se_raw_unscaled <- as.numeric(fit_raw$se * recipe$y$sd)
 
-  # Compare with reasonable tolerances (iterative solver may land within small numerical deltas)
+# Compare with reasonable tolerances (iterative solver may land within small numerical deltas)
   est_rel_diff <- abs(fit_std$estimate - est_raw_unscaled) / max(1, abs(fit_std$estimate))
-  se_rel_diff  <- abs(fit_std$std_error - se_raw_unscaled) / fit_std$std_error
+  se_rel_diff <- abs(fit_std$se - se_raw_unscaled) / fit_std$se
 
-  expect_lt(est_rel_diff, 0.01)   # < 1% relative difference in point estimate
-  expect_lt(se_rel_diff, 0.20)     # < 20% relative difference in SE
+  expect_lt(est_rel_diff, 0.01) # < 1% relative difference in point estimate
+  expect_lt(se_rel_diff, 0.20) # < 20% relative difference in SE
 })
-

--- a/tests/testthat/test-exptilt.R
+++ b/tests/testthat/test-exptilt.R
@@ -46,12 +46,12 @@ test_that("exptilt returns OK data for correct input", {
   expect_s3_class(res, "nmar_result")
   expect_type(res, "list")
   expect_type(res[['estimate']], "double")
-  expect_type(res[['std_error']], "double")
+  expect_type(res[['se']], "double")
   expect_length(res[['estimate']], 1)
-  expect_length(res[['std_error']], 1)
+  expect_length(res[['se']], 1)
   expect_true(is.finite(res[['estimate']]))
-  expect_true(is.finite(res[['std_error']]))
-  expect_gt(res[['std_error']], 0)
+  expect_true(is.finite(res[['se']]))
+  expect_gt(res[['se']], 0)
 })
 
 test_that("exptilt returns error for faulty data", {

--- a/tests/testthat/test-s3-registrations.R
+++ b/tests/testthat/test-s3-registrations.R
@@ -3,7 +3,7 @@ skip_if_not_installed("generics")
 make_test_result <- function() {
   NMAR:::new_nmar_result(
     estimate = 1.2,
-    std_error = 0.05,
+    se = 0.05,
     converged = TRUE,
     inference = list(variance_method = "delta"),
     sample = list(n_total = 10L, n_respondents = 8L, is_survey = FALSE, design = NULL),
@@ -29,5 +29,5 @@ test_that("nmar_result S3 generics are registered", {
   capture.output(print(res))
   capture.output(print(sum_obj))
 
-  # expect_true(utils::isS3stdGeneric("autoplot"))
+# expect_true(utils::isS3stdGeneric("autoplot"))
 })

--- a/vignettes/developing_new_nmar_estimator.Rmd
+++ b/vignettes/developing_new_nmar_estimator.Rmd
@@ -212,7 +212,7 @@ math here (e.g., likelihood, gradients, constraints).
 Call `new_nmar_result()` inside your constructor so the object carries class
 `c("nmar_result_<method>", "nmar_result")` and shares the standard layout:
 
-- Scalar fields: `estimate`, `estimate_name`, `std_error`, `converged`.
+- Scalar fields: `estimate`, `estimate_name`, `se`, `converged`.
 - Lists: `model` (coefficients/vcov), `weights_info`, `sample`, `inference`,
   `diagnostics`, `meta`, `extra`.
 
@@ -224,7 +224,7 @@ Minimal constructor example (inside `src_dev/engines/<method>/impl/constructors.
 
 ```r
 #' @keywords internal
-new_nmar_result_method <- function(estimate, std_error,
+new_nmar_result_method <- function(estimate, se,
                                    coefficients = NULL, vcov = NULL,
                                    weights = NULL, sample = list(),
                                    inference = list(variance_method = NA_character_,
@@ -241,7 +241,7 @@ new_nmar_result_method <- function(estimate, std_error,
   result <- new_nmar_result(
     estimate = estimate,
     estimate_name = sample$outcome_var,
-    std_error = std_error,
+    se = se,
     converged = TRUE,
     model = list(coefficients = coefficients, vcov = vcov),
     weights_info = list(values = weights, trimmed_fraction = NA_real_),

--- a/vignettes/tutorial_exptilt.Rmd
+++ b/vignettes/tutorial_exptilt.Rmd
@@ -92,7 +92,7 @@ print(res)
 ```{r}
 cat('True Y mean:          ', sprintf('%.4f', mean(y_original)), '\n')
 est <- as.numeric(res$estimate)
-se <- res$std_error
+se <- res$se
 cat('Est Y mean (NMAR):    ', sprintf('%.4f', est),
     '  3σ interval: (', sprintf('%.4f', est - 3 * se),
     ', ', sprintf('%.4f', est + 3 * se), 'σ=', sprintf('%.4f', se), ')\n')


### PR DESCRIPTION
Primary estimand output formatted as “<name> mean: <value> (<SE>)” in  print and summary.
Canonical field `se` stored on results instead of `std_error`. 
Added se() function as a simple extractor.
Consistent digits across print/summary via options(nmar.digits) (default 6).
Tidy/glance retain a std.error column name for broom compatibility, populated from se.

Fixes #74