### PR TITLE
allow respondent only data

### DIFF
--- a/src_dev/engines/el/impl/constructors.R
+++ b/src_dev/engines/el/impl/constructors.R
@@ -78,7 +78,7 @@ new_nmar_result_el <- function(y_hat, se, weights, coefficients, vcov,
 #'   names in `auxiliary_means`. See Qin, Leung and Shao (2002) for the EL
 #'   formulation.
 #' @keywords internal
-prepare_el_inputs <- function(formula, data, response_predictors) {
+prepare_el_inputs <- function(formula, data, response_predictors, require_na = TRUE) {
   if (!inherits(formula, "formula") || length(formula) != 3 || length(all.vars(formula[[2]])) != 1) {
     stop("`formula` must be a two-sided formula with a single variable on the LHS, e.g., y ~ x1 + x2.", call. = FALSE)
   }
@@ -87,7 +87,7 @@ prepare_el_inputs <- function(formula, data, response_predictors) {
   outcome_var <- all.vars(formula[[2]])
   rhs_vars <- all.vars(formula[[3]])
   if (!outcome_var %in% names(data)) stop(sprintf("Outcome variable '%s' not found in the data.", outcome_var), call. = FALSE)
-  if (!anyNA(data[[outcome_var]])) stop(sprintf("Outcome variable '%s' must contain NA values to indicate nonresponse.", outcome_var), call. = FALSE)
+  if (isTRUE(require_na) && !anyNA(data[[outcome_var]])) stop(sprintf("Outcome variable '%s' must contain NA values to indicate nonresponse.", outcome_var), call. = FALSE)
   response_predictors_full <- c(outcome_var, response_predictors)
   if (!is.null(response_predictors)) {
     if (!is.character(response_predictors)) stop("`response_predictors` must be a character vector of variable names.", call. = FALSE)

--- a/src_dev/engines/el/run_engine.R
+++ b/src_dev/engines/el/run_engine.R
@@ -21,6 +21,7 @@ run_engine.nmar_engine_el <- function(engine, task) {
     response_predictors = response_predictors,
     auxiliary_means = design_info$auxiliary_means,
     standardize = design_info$standardize,
+    n_total = engine$n_total,
     trim_cap = engine$trim_cap,
     control = engine$control,
     solver_args = engine$solver_args,

--- a/src_dev/nmar.R
+++ b/src_dev/nmar.R
@@ -35,6 +35,12 @@ nmar <- function(formula, data, engine, response_predictors = NULL) {
   )
 
   traits <- engine_traits(engine)
+  # Activate respondents-only relaxation only when the engine supplies
+  # the required extra information (currently: n_total for EL).
+  if (isTRUE(traits$allow_respondents_only)) {
+    has_n_total <- !is.null(engine$n_total)
+    traits$allow_respondents_only <- isTRUE(has_n_total)
+  }
   validate_nmar_args(spec, traits)
 
   # Wrap the validated spec and engine traits into a task object so every

--- a/src_dev/shared/input_pipeline.R
+++ b/src_dev/shared/input_pipeline.R
@@ -81,7 +81,8 @@ engine_traits.default <- function(engine) {
   list(
     allow_outcome_in_missingness = FALSE,
     allow_covariate_overlap = FALSE,
-    requires_single_outcome = TRUE
+    requires_single_outcome = TRUE,
+    allow_respondents_only = FALSE
   )
 }
 
@@ -98,7 +99,8 @@ engine_traits.nmar_engine_el <- function(engine) {
     engine_traits.default(engine),
     list(
       allow_outcome_in_missingness = TRUE,
-      allow_covariate_overlap = TRUE
+      allow_covariate_overlap = TRUE,
+      allow_respondents_only = TRUE
     )
   )
 }
@@ -140,7 +142,8 @@ validate_nmar_args <- function(spec, traits = list()) {
       covariates_for_outcome = spec$auxiliary_vars,
       covariates_for_missingness = spec$response_predictors,
       allow_outcome_in_missingness = traits$allow_outcome_in_missingness,
-      allow_covariate_overlap = traits$allow_covariate_overlap
+      allow_covariate_overlap = traits$allow_covariate_overlap,
+      allow_respondents_only = isTRUE(traits$allow_respondents_only)
     )
   } else {
     missing_outcomes <- setdiff(spec$outcome, names(spec$data))

--- a/src_dev/validation/validate_data.R
+++ b/src_dev/validation/validate_data.R
@@ -11,6 +11,9 @@
 #'   response-model covariates (default `FALSE`).
 #' @param allow_covariate_overlap Logical; allow overlap between outcome and response
 #'   covariate sets (default `FALSE`).
+#' @param allow_respondents_only Logical; allow datasets with no missing outcome
+#'   values (respondents-only). When TRUE, the caller is expected to provide any
+#'   additional information required by the engine (e.g., total sample size).
 #' @return Returns `invisible(NULL)` on success, stopping with a descriptive error on failure.
 #' @keywords internal
 validate_data <- function(data,
@@ -18,8 +21,9 @@ validate_data <- function(data,
                           covariates_for_outcome,
                           covariates_for_missingness = character(),
                           allow_outcome_in_missingness = FALSE,
-                          allow_covariate_overlap = FALSE) {
-  # Validate data object type
+                          allow_covariate_overlap = FALSE,
+                          allow_respondents_only = FALSE) {
+# Validate data object type
   if (!inherits(data, c("data.frame", "survey.design"))) {
     stop("'data' must be a data.frame or survey.design object. Received: ", class(data)[1])
   }
@@ -83,9 +87,11 @@ validate_data <- function(data,
     )
   }
 
-# Check for required NAs in outcome
+# Check for required NAs in outcome unless respondents-only is allowed
   if (!anyNA(data[[outcome_variable]])) {
-    stop("Outcome variable '", outcome_variable, "' must contain NA values.")
+    if (!isTRUE(allow_respondents_only)) {
+      stop("Outcome variable '", outcome_variable, "' must contain NA values.")
+    }
   }
 
 # Check for at least one non-NA value in outcome


### PR DESCRIPTION
Added engine trait `allow_respondents_only`. Allowed for el, but only relaxing the “outcome must contain NA” check when the engine supplies n_total. Otherwise, validation stays strict and the old error is preserved.

Closes #80 