### PR TITLE
auto infer sample means

### DIFF
--- a/src_dev/engines/el/impl/core.R
+++ b/src_dev/engines/el/impl/core.R
@@ -59,15 +59,68 @@ el_estimator_core <- function(full_data, respondent_data, respondent_weights, N_
 
 # 1. Data Preparation
   has_aux <- !is.null(internal_formula$auxiliary)
-  if (has_aux && is.null(auxiliary_means)) {
-    message("An `auxiliary` formula was created but no `auxiliary_means` were given. Ignoring auxiliary information.")
-    has_aux <- FALSE
-  }
 
   response_model_formula <- update(internal_formula$response, NULL ~ .)
   response_model_matrix_unscaled <- model.matrix(response_model_formula, data = respondent_data)
-  auxiliary_matrix_unscaled <- if (has_aux) model.matrix(internal_formula$auxiliary, data = respondent_data) else matrix(nrow = nrow(respondent_data), ncol = 0)
-  mu_x_unscaled <- if (has_aux) auxiliary_means else NULL
+
+  if (has_aux) {
+    # Build auxiliary design on respondents
+    auxiliary_matrix_unscaled <- model.matrix(internal_formula$auxiliary, data = respondent_data)
+
+    # If user did not supply population moments, infer from the full sample
+    if (is.null(auxiliary_means)) {
+      if (inherits(full_data, "survey.design")) {
+        mm_full <- model.matrix(internal_formula$auxiliary, data = full_data$variables)
+        w_full <- as.numeric(weights(full_data))
+        # Align columns with respondent design (drop absent levels in respondents)
+        common_cols <- intersect(colnames(auxiliary_matrix_unscaled), colnames(mm_full))
+        if (length(common_cols) == 0L) {
+          # No overlap; disable auxiliaries gracefully
+          auxiliary_matrix_unscaled <- matrix(nrow = nrow(respondent_data), ncol = 0)
+          mu_x_unscaled <- NULL
+          has_aux <- FALSE
+        } else {
+          mm_full <- mm_full[, common_cols, drop = FALSE]
+          # Weighted means of model-matrix columns
+          mu <- as.numeric(colSums(mm_full * w_full) / sum(w_full))
+          names(mu) <- colnames(mm_full)
+          # Reorder to respondent design
+          auxiliary_matrix_unscaled <- auxiliary_matrix_unscaled[, common_cols, drop = FALSE]
+          mu_x_unscaled <- mu[colnames(auxiliary_matrix_unscaled)]
+          message("No auxiliary_means supplied; inferred from design-weighted sample and treated as fixed.")
+        }
+      } else {
+        mm_full <- model.matrix(internal_formula$auxiliary, data = full_data)
+        common_cols <- intersect(colnames(auxiliary_matrix_unscaled), colnames(mm_full))
+        if (length(common_cols) == 0L) {
+          auxiliary_matrix_unscaled <- matrix(nrow = nrow(respondent_data), ncol = 0)
+          mu_x_unscaled <- NULL
+          has_aux <- FALSE
+        } else {
+          mm_full <- mm_full[, common_cols, drop = FALSE]
+          mu <- colMeans(mm_full)
+          # Ensure naming and order
+          auxiliary_matrix_unscaled <- auxiliary_matrix_unscaled[, common_cols, drop = FALSE]
+          mu_x_unscaled <- as.numeric(mu[colnames(auxiliary_matrix_unscaled)])
+          names(mu_x_unscaled) <- colnames(auxiliary_matrix_unscaled)
+          message("No auxiliary_means supplied; inferred from sample and treated as fixed.")
+        }
+      }
+    } else {
+      # Use provided means; restrict/reorder to match respondent design
+      keep <- intersect(names(auxiliary_means), colnames(auxiliary_matrix_unscaled))
+      auxiliary_matrix_unscaled <- auxiliary_matrix_unscaled[, keep, drop = FALSE]
+      mu_x_unscaled <- as.numeric(auxiliary_means[keep])
+      names(mu_x_unscaled) <- keep
+      if (ncol(auxiliary_matrix_unscaled) == 0L) {
+        has_aux <- FALSE
+        mu_x_unscaled <- NULL
+      }
+    }
+  } else {
+    auxiliary_matrix_unscaled <- matrix(nrow = nrow(respondent_data), ncol = 0)
+    mu_x_unscaled <- NULL
+  }
 
 # 2. Scaling
   scaling_result <- validate_and_apply_nmar_scaling(


### PR DESCRIPTION
If auxiliaries are present in the formula and auxiliary_means is not provided:
- Data frame (IID): compute mu from the full sample as column means of the auxiliary model matrix and use them as fixed moments
- Survey design: compute design-weighted means of the auxiliary model matrix using the design weights

Closes #82 